### PR TITLE
Retry logic for database connection attempts

### DIFF
--- a/jobs/sync/init.go
+++ b/jobs/sync/init.go
@@ -131,7 +131,7 @@ func secretsOverride() {
 
 func initDBs() {
 	var err error
-	recruitmentListDBService, err = rdb.NewManagementUserDBService(db.DBConfigFromYamlObj(conf.DBConfigs.RecruitmentListDB, nil))
+	recruitmentListDBService, err = rdb.NewRecruitmentListDBService(db.DBConfigFromYamlObj(conf.DBConfigs.RecruitmentListDB, nil))
 	if err != nil {
 		slog.Error("Error connecting to recruitment list DB", slog.String("error", err.Error()))
 	}

--- a/pkg/db/recruitment-list/db.go
+++ b/pkg/db/recruitment-list/db.go
@@ -35,7 +35,7 @@ type RecruitmentListDBService struct {
 	InstanceIDs     []string
 }
 
-func NewManagementUserDBService(configs db.DBConfig) (*RecruitmentListDBService, error) {
+func NewRecruitmentListDBService(configs db.DBConfig) (*RecruitmentListDBService, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(configs.Timeout)*time.Second)
 	defer cancel()
 

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"errors"
+	"log/slog"
+	"time"
+)
+
+func InitDBWithRetry(name string, initFunc func() error) error {
+	const maxRetries = 25
+	const retryInterval = 30 * time.Second
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err := initFunc()
+		if err == nil {
+			return nil
+		}
+		if attempt == maxRetries {
+			slog.Error("Error connecting to "+name+" DB, final attempt failed",
+				slog.Any("error", err),
+				slog.Int("attempt", attempt),
+				slog.Int("max_retries", maxRetries))
+		} else {
+			slog.Error("Error connecting to "+name+" DB, retrying in 30 seconds...",
+				slog.Any("error", err),
+				slog.Int("attempt", attempt),
+				slog.Int("max_retries", maxRetries))
+			time.Sleep(retryInterval)
+		}
+	}
+	return errors.New("failed to connect to " + name + " DB after all retries")
+}

--- a/services/recruitment-list-api/init.go
+++ b/services/recruitment-list-api/init.go
@@ -180,13 +180,11 @@ func initDBWithRetry(name string, initFunc func() error) error {
 		if err == nil {
 			return nil
 		}
-		if attempt < maxRetries {
-			slog.Error("Error connecting to "+name+" DB, retrying in 30 seconds...",
-				slog.Any("error", err),
-				slog.Int("attempt", attempt),
-				slog.Int("max_retries", maxRetries))
-			time.Sleep(retryInterval)
-		}
+		slog.Error("Error connecting to "+name+" DB, retrying in 30 seconds...",
+			slog.Any("error", err),
+			slog.Int("attempt", attempt),
+			slog.Int("max_retries", maxRetries))
+		time.Sleep(retryInterval)
 	}
 	return errors.New("failed to connect to " + name + " DB after all retries")
 }

--- a/services/recruitment-list-api/init.go
+++ b/services/recruitment-list-api/init.go
@@ -171,15 +171,46 @@ func secretsOverride() {
 }
 
 func initDBs() {
-	var err error
-	recruitmentListDBService, err = rdb.NewManagementUserDBService(db.DBConfigFromYamlObj(conf.DBConfigs.RecruitmentListDB, nil))
-	if err != nil {
-		slog.Error("Error connecting to recruitment list DB", slog.String("error", err.Error()))
+	const maxRetries = 25
+	const retryInterval = 30 * time.Second
+
+	// Initialize recruitment list DB with retry
+	var recruitmentListErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		recruitmentListDBService, recruitmentListErr = rdb.NewRecruitmentListDBService(db.DBConfigFromYamlObj(conf.DBConfigs.RecruitmentListDB, nil))
+		if recruitmentListErr == nil && recruitmentListDBService != nil {
+			break
+		}
+		if attempt < maxRetries {
+			slog.Error("Error connecting to recruitment list DB, retrying in 30 seconds...",
+				slog.String("error", recruitmentListErr.Error()),
+				slog.Int("attempt", attempt),
+				slog.Int("max_retries", maxRetries))
+			time.Sleep(retryInterval)
+		} else {
+			slog.Error("Failed to connect to recruitment list DB after all retries", slog.String("error", recruitmentListErr.Error()))
+			panic("Failed to establish recruitment list DB connection after 25 retries")
+		}
 	}
 
-	studyDBService, err = sdb.NewStudyDBService(db.DBConfigFromYamlObj(conf.DBConfigs.StudyDB, nil))
-	if err != nil {
-		slog.Error("Error connecting to Study DB", slog.String("error", err.Error()))
+	// Initialize study DB with retry
+	var studyErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		studyDBService, studyErr = sdb.NewStudyDBService(db.DBConfigFromYamlObj(conf.DBConfigs.StudyDB, nil))
+		if studyErr == nil && studyDBService != nil {
+			break
+		}
+		if attempt < maxRetries {
+			slog.Error("Error connecting to Study DB, retrying in 30 seconds...",
+				slog.String("error", studyErr.Error()),
+				slog.Int("attempt", attempt),
+				slog.Int("max_retries", maxRetries))
+			time.Sleep(retryInterval)
+		} else {
+			slog.Error("Failed to connect to Study DB after all retries", slog.String("error", studyErr.Error()))
+			panic("Failed to establish Study DB connection after 25 retries")
+		}
+
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automatic DB initialization retry logic (up to 25 attempts with 30s intervals) for multiple databases to improve startup reliability.
  * Enhanced per-attempt error logging and final failure handling to surface diagnostics when initialization ultimately fails.

* **Refactor**
  * Renamed an internal recruitment-list DB constructor/service for clearer organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `InitDBWithRetry` (25 retries, 30s interval) and apply it to recruitment list and study DB init; rename constructor to `NewRecruitmentListDBService`.
> 
> - **DB Utilities**:
>   - Add `pkg/db/utils.go` with `InitDBWithRetry` (25 attempts, 30s backoff) and structured error logging.
> - **Services/Jobs Initialization**:
>   - Wrap DB inits in `jobs/sync/init.go` and `services/recruitment-list-api/init.go` with `InitDBWithRetry`; panic after final failure.
> - **Recruitment List DB**:
>   - Rename constructor `NewManagementUserDBService` to `NewRecruitmentListDBService` in `pkg/db/recruitment-list/db.go` and update callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eab44ede3285a4e6072836191214bbd8e53ccf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->