### PR TITLE
Add tags functionality to recruitment lists

### DIFF
--- a/pkg/db/recruitment-list/recruitment-lists.go
+++ b/pkg/db/recruitment-list/recruitment-lists.go
@@ -76,6 +76,7 @@ func (dbService *RecruitmentListDBService) GetRecruitmentListsInfos() ([]Recruit
 		"id":          1,
 		"name":        1,
 		"description": 1,
+		"tags":        1,
 		"createdAt":   1,
 	}
 	opts := options.Find()

--- a/pkg/db/recruitment-list/tags.go
+++ b/pkg/db/recruitment-list/tags.go
@@ -1,0 +1,56 @@
+package recruitmentlist
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func (dbService *RecruitmentListDBService) UpdateRecruitmentListTags(listID string, tags []string) error {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	_id, err := primitive.ObjectIDFromHex(listID)
+	if err != nil {
+		return err
+	}
+
+	filter := bson.M{"_id": _id}
+	update := bson.M{"$set": bson.M{"tags": tags}}
+	_, err = dbService.collectionRecruitmentLists().UpdateOne(ctx, filter, update)
+	return err
+}
+
+func (dbService *RecruitmentListDBService) GetRecruitmentListTags() ([]string, error) {
+	ctx, cancel := dbService.getContext()
+	defer cancel()
+
+	pipeline := mongo.Pipeline{
+		bson.D{{Key: "$project", Value: bson.M{"tags": 1}}},
+		bson.D{{Key: "$unwind", Value: "$tags"}},
+		bson.D{{Key: "$group", Value: bson.M{"_id": "$tags"}}},
+		bson.D{{Key: "$sort", Value: bson.M{"_id": 1}}},
+	}
+
+	cursor, err := dbService.collectionRecruitmentLists().Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []struct {
+		Tag string `bson:"_id"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+
+	tags := make([]string, 0, len(results))
+	for _, result := range results {
+		if result.Tag == "" {
+			continue
+		}
+		tags = append(tags, result.Tag)
+	}
+	return tags, nil
+}

--- a/pkg/db/recruitment-list/types.go
+++ b/pkg/db/recruitment-list/types.go
@@ -112,6 +112,7 @@ type RecruitmentList struct {
 	ID                   primitive.ObjectID    `json:"id,omitempty" bson:"_id,omitempty"`
 	Name                 string                `json:"name,omitempty" bson:"name,omitempty"`
 	Description          string                `json:"description,omitempty" bson:"description,omitempty"`
+	Tags                 []string              `json:"tags,omitempty" bson:"tags,omitempty"`
 	CreatedAt            time.Time             `json:"createdAt,omitempty" bson:"createdAt,omitempty"`
 	CreatedBy            string                `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 	ParticipantInclusion ParticipantInclusion  `json:"participantInclusion,omitempty" bson:"participantInclusion,omitempty"`


### PR DESCRIPTION
- Introduced a new `tags` field in the `RecruitmentList` struct.
- Implemented `UpdateRecruitmentListTags` and `GetRecruitmentListTags` methods in the `RecruitmentListDBService` for managing tags.
- Added API endpoints for retrieving and updating recruitment list tags.
- Updated the recruitment lists API handler to include new tag-related functionalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag management for recruitment lists. Users can now view all available tags across recruitment lists and update tags for individual recruitment lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->